### PR TITLE
Add composer.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
 .phpcs-cache
 .phpunit.result.cache
+composer.lock
 infection.log


### PR DESCRIPTION
This is library so `composer.lock` should not be managed by VCS